### PR TITLE
Fix: allow renaming session when only capitalization changes (#31)

### DIFF
--- a/js/background/background.js
+++ b/js/background/background.js
@@ -1024,6 +1024,10 @@ async function handleImportNewSession(urlList) {
 async function handleUpdateSessionName(sessionId, sessionName, deleteOld) {
     // check to make sure session name doesn't already exist
     const existingSession = await dbService.fetchSessionByName(sessionName);
+    // Fix: allow renaming when only capitalization is changed
+if (existingSession && existingSession.id === sessionId) {
+    return spacesService.updateSessionName(sessionId, sessionName) ?? false;
+}
 
     // if session with same name already exist, then prompt to override the existing session
     if (existingSession) {


### PR DESCRIPTION
This PR fixes the problem where you cannot rename a space if only the
capitalization changes (for example: "foo" → "Foo").  
The extension was treating them as the same name and blocking the rename.

I updated the code so that capitalization-only name changes work correctly.
